### PR TITLE
Allow merging by default

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -409,12 +409,17 @@ class File implements FileInterface
 
     /**
      * @param array $metadata Meta data
+     * @param bool $overwrite Overwrite whole metadata instead of assoc merging.
      * @return \Phauthentic\Infrastructure\Storage\FileInterface
      */
-    public function withMetadata(array $metadata): FileInterface
+    public function withMetadata(array $metadata, bool $overwrite = false): FileInterface
     {
         $that = clone $this;
-        $that->metadata = $metadata;
+        if ($overwrite) {
+            $that->metadata = $metadata;
+        } else {
+            $that->metadata = $metadata + $that->metadata;
+        }
 
         return $that;
     }

--- a/src/FileInterface.php
+++ b/src/FileInterface.php
@@ -160,7 +160,7 @@ interface FileInterface extends JsonSerializable
      * @param array $metadata Metadata
      * @return \Phauthentic\Infrastructure\Storage\FileInterface
      */
-    public function withMetadata(array $metadata): FileInterface;
+    public function withMetadata(array $metadata, bool $overwrite = false): FileInterface;
 
     /**
      * Removes all metadata


### PR DESCRIPTION
In this specific case I wanted to merge in an array.
So doing this as in cake core with allowing to merge the assoc array by default and providing a way to overwrite if needed seems more intuitive at least.

I am not so sure in general about the naming of the methods
- withMetadata()
- withMetadataKey()

technically it would be "datum" for singular, but that is rarely used.

The latter might be more sth like `withMetadataValue($key, $value)` then.