### PR TITLE
Read metadata key.

### DIFF
--- a/docs/Example.md
+++ b/docs/Example.md
@@ -73,7 +73,7 @@ $file = FileFactory::fromDisk('./tests/Fixtures/titus.jpg', 'local')
         'one' => 'two',
         'two' => 'one'
     ])
-    ->withMetadataKey('bar', 'foo');
+    ->withMetadataElement('bar', 'foo');
 
 $file = $fileStorage->store($file);
 

--- a/docs/The-File-Object.md
+++ b/docs/The-File-Object.md
@@ -86,7 +86,7 @@ $file
         'one' => 'two',
         'two' => 'one'
     ])
-    ->withMetadataKey('bar', 'foo');
+    ->withMetadataElement('bar', 'foo');
     // removes a specific key
     ->withoutMetadataKey('one');
     // removes all meta data
@@ -100,7 +100,7 @@ $file->metaData();
 ```
 
 ```php
-$file->metaDataKey('foo');
+$file->metadataElement('foo');
 ```
 
 ## Extending functionality

--- a/example.php
+++ b/example.php
@@ -134,7 +134,7 @@ $file = FileFactory::fromDisk('./tests/Fixtures/titus.jpg', 'local')
         'one' => 'two',
         'two' => 'one'
     ])
-    ->withMetadataKey('bar', 'foo');
+    ->withMetadataElement('bar', 'foo');
 
 $file = $fileStorage->store($file);
 

--- a/src/File.php
+++ b/src/File.php
@@ -429,7 +429,7 @@ class File implements FileInterface
      * @param mixed $data Data
      * @return \Phauthentic\Infrastructure\Storage\FileInterface
      */
-    public function withMetadataKey(string $name, $data): FileInterface
+    public function withMetadataElement(string $name, $data): FileInterface
     {
         $that = clone $this;
         $that->metadata[$name] = $data;
@@ -441,7 +441,7 @@ class File implements FileInterface
      * @param string $name Name
      * @return \Phauthentic\Infrastructure\Storage\FileInterface
      */
-    public function withoutMetadataKey(string $name): FileInterface
+    public function withoutMetadataElement(string $name): FileInterface
     {
         $that = clone $this;
         unset($that->metadata[$name]);
@@ -466,6 +466,24 @@ class File implements FileInterface
     public function metadata(): array
     {
         return $this->metadata;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @throws \RuntimeException
+     *
+     * @return mixed
+     */
+    public function metadataElement(string $key)
+    {
+        if (!isset($this->metadata[$key])) {
+            throw new RuntimeException(
+                'Metadata key does not exist'
+            );
+        }
+
+        return $this->metadata[$key];
     }
 
     /**

--- a/src/FileInterface.php
+++ b/src/FileInterface.php
@@ -176,14 +176,14 @@ interface FileInterface extends JsonSerializable
      * @param mixed $data
      * @return \Phauthentic\Infrastructure\Storage\FileInterface
      */
-    public function withMetadataKey(string $key, $data): FileInterface;
+    public function withMetadataElement(string $key, $data): FileInterface;
 
     /**
      * Removes a key from the metadata array
      * @param string $name Name
      * @return \Phauthentic\Infrastructure\Storage\FileInterface
      */
-    public function withoutMetadataKey(string $name): FileInterface;
+    public function withoutMetadataElement(string $name): FileInterface;
 
     /**
      * Stream resource of the file to be stored

--- a/src/Processor/StackProcessor.php
+++ b/src/Processor/StackProcessor.php
@@ -24,6 +24,9 @@ use Phauthentic\Infrastructure\Storage\FileInterface;
  */
 class StackProcessor implements ProcessorInterface
 {
+    /**
+     * @var \Phauthentic\Infrastructure\Storage\Processor\ProcessorInterface[]
+     */
     protected array $processors = [];
 
     /**

--- a/tests/TestCase/FileStorageTest.php
+++ b/tests/TestCase/FileStorageTest.php
@@ -58,7 +58,7 @@ class FileStorageTest extends TestCase
         $file = FileFactory::fromDisk($fileOnDisk, 'local')
             ->withUuid('914e1512-9153-4253-a81e-7ee2edc1d973')
             ->belongsToModel('User', '1')
-            ->withMetadataKey('bar', 'foo');
+            ->withMetadataElement('bar', 'foo');
 
         $file = $fileStorage->store($file);
 

--- a/tests/TestCase/FileTest.php
+++ b/tests/TestCase/FileTest.php
@@ -66,7 +66,7 @@ class FileTest extends TestCase
                 'one' => 'two',
                 'two' => 'one'
             ])
-            ->withMetadataKey('bar', 'foo');
+            ->withMetadataElement('bar', 'foo');
 
         $file = $file->buildPath($pathBuilder);
 
@@ -91,7 +91,7 @@ class FileTest extends TestCase
         $this->assertIsArray($file->toArray());
         $this->assertIsString(json_encode($file));
 
-        $file = $file->withoutMetadataKey('bar');
+        $file = $file->withoutMetadataElement('bar');
         $expectedMetadata = [
             'one' => 'two',
             'two' => 'one',


### PR DESCRIPTION
The metadata`key`() was never ideal from the naming.
As only the access to this element is a key, not the whole thing

I propose naming it element then instead.

Also, since there is assoc adding, there should also be assoc reading IMO
I added `metadataElement()` for this.

What do you think?