### PR TITLE
Add code sniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "require-dev": {
         "instituteweb/composer-scripts": "^1.1",
-        "phauthentic/file-storage-image-processor": "dev-develop"
+        "phauthentic/file-storage-image-processor": "dev-develop",
+        "spryker/code-sniffer": "^0.15.6"
     },
     "suggest": {
         "phauthentic/file-storage-image-processor": "For image processing"
@@ -63,11 +64,11 @@
         ],
         "cscheck": [
             "\\InstituteWeb\\ComposerScripts\\ImprovedScriptExecution::apply",
-            "phpcs src/ tests/ --standard=phpcs.xml -s"
+            "phpcs"
         ],
         "csfix": [
             "\\InstituteWeb\\ComposerScripts\\ImprovedScriptExecution::apply",
-            "phpcbf src/ tests/ --standard=phpcs.xml"
+            "phpcbf"
         ],
         "analyze": [
             "\\InstituteWeb\\ComposerScripts\\ImprovedScriptExecution::apply",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,25 @@
 <?xml version="1.0"?>
 <ruleset name="Phauthentic">
     <arg name="tab-width" value="4"/>
+
+    <rule ref="vendor/spryker/code-sniffer/Spryker/ruleset.xml"/>
+    <file>src/</file>
+    <file>tests/</file>
+
+    <rule ref="PSR2.Classes.PropertyDeclaration">
+        <severity>0</severity>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="newlinesCountBetweenOpenTagAndDeclare" value="2"/>
+        </properties>
+    </rule>
+
+    <rule ref="Spryker">
+        <exclude name="Spryker.Formatting.MethodSignatureParametersLineBreakMethod"/>
+    </rule>
+
     <rule ref="PSR12">
         <exclude name="Generic.Files.LineLength.TooLong"/>
         <exclude name="PSR2.Classes.PropertyDeclaration"/>
@@ -8,7 +27,5 @@
         <!-- Use this if you want tabs over spaces -->
         <!-- <exclude name="Generic.WhiteSpace.DisallowTabIndent"/> -->
     </rule>
-    <!-- Use this if you want tabs over spaces -->
-    <!-- <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>-->
-    <file>./src</file>
+
 </ruleset>

--- a/src/File.php
+++ b/src/File.php
@@ -450,9 +450,9 @@ class File implements FileInterface
     }
 
     /**
-     * @return $this
+     * @return static
      */
-    public function withoutMetadata(): self
+    public function withoutMetadata()
     {
         $that = clone $this;
         $that->metadata = [];

--- a/src/FileInterface.php
+++ b/src/FileInterface.php
@@ -165,9 +165,9 @@ interface FileInterface extends JsonSerializable
     /**
      * Removes all metadata
      *
-     * @return \Phauthentic\Infrastructure\Storage\FileInterface
+     * @return static
      */
-    public function withoutMetadata(): FileInterface;
+    public function withoutMetadata();
 
     /**
      * Adds a single key and value to the metadata array


### PR DESCRIPTION
Refs https://github.com/dereuromark/cakephp-file-storage/pull/1

Adding a professional cs sniffer ruleset prevents a lot of issues by design
as the result of this cs fail result can show.

More CS fixes need to be done here of course
Many can be autofixed given the standard included.